### PR TITLE
Fix for dirname returning "\"

### DIFF
--- a/src/Dropbox/API.php
+++ b/src/Dropbox/API.php
@@ -101,7 +101,11 @@ class Dropbox_API {
      */
     public function putFile($path, $file, $root = null) {
 
-        $directory = dirname($path);
+        if (dirname($path) == '\\') {
+            $directory = "/";
+        } else {
+            $directory = dirname($path);
+        }
         $filename = basename($path);
 
         if($directory==='.') $directory = '';


### PR DESCRIPTION
For paths like "/myFile.txt" dirname returns "\" causing the API call to fail.
