### PR TITLE
Fix location of PHP binary in tests/setup shebang

### DIFF
--- a/tests/setup
+++ b/tests/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 // We want to know if something goes wrong


### PR DESCRIPTION
PHP binary can be located in different directories depending on the OS. Using `#!/usr/bin/env php` instead of `#!/usr/bin/php` avoids problems when, for instance, multiple versions of PHP are installed.

I spent hours trying to figure out why none of oauth modules were not working despite being installed, but it turned out that by calling `./setup` I was simply invoking php 5.3 instead of php 5.4 (which, of course, was misconfigured); this was a really difficult issue to spot.

`#!/usr/bin/env php` is used in Symfony's console, by the way.
