### PR TITLE
Fix bug with @added annotation

### DIFF
--- a/src/Dropbox/API.php
+++ b/src/Dropbox/API.php
@@ -476,8 +476,8 @@ class Dropbox_API {
      *
      * Returns metadata for all files and folders that match the search query.
      *
-	 * @added by: diszo.sasil
-	 *
+     * @author: diszo.sasil
+     *
      * @param string $query
      * @param string $root Use this to override the default root path (sandbox/dropbox)
 	 * @param string $path


### PR DESCRIPTION
Using non-standart annotation `@added` cause next error: `The annotation "@added" in method Dropbox_API::search() was never imported. Did you maybe forget to add a "use" statement for this annotation?`